### PR TITLE
Pull functionality out into more specific modules.

### DIFF
--- a/auacm/app/__init__.py
+++ b/auacm/app/__init__.py
@@ -6,39 +6,11 @@ from sqlalchemy.orm import Session
 from sqlalchemy.ext.automap import automap_base
 import os.path
 
+
 # flask setup
 app = Flask(__name__)
 app.config.from_pyfile('config.py') # not sure if this works
 
-# bcrypt setup
-bcrypt = Bcrypt(app)
 
-# database setup
-Base = automap_base()
-engine = create_engine('mysql://acm@localhost/acm')
-connection = engine.connect()
-Base.prepare(engine, reflect=True)
-session = Session(engine)
-
-# login session setup
-login_manager = LoginManager()
-login_manager.init_app(app)
-
-from app.modules.user_manager.models import User
-@login_manager.user_loader
-def load_user(user_id):
-    result = session.query(Base.classes.users).filter(Base.classes.users.username==user_id).first()
-    if result:
-        return User(result)
-    else:
-        return None
-
-# dirty hack from StackOverflow to allow us to serve static html
-def serve_html(filename):
-    try:
-        src = os.getcwd() + '/app/static/html/' + filename
-        return Response(open(src).read(), mimetype="text/html")
-    except IOError as exc:
-        return str(exc)
-
+# Initialize handler functions.
 from app import views

--- a/auacm/app/database.py
+++ b/auacm/app/database.py
@@ -1,0 +1,11 @@
+'''Database handlers'''
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.ext.automap import automap_base
+
+# database setup
+Base = automap_base()
+engine = create_engine('mysql://acm@localhost/acm')
+connection = engine.connect()
+Base.prepare(engine, reflect=True)
+session = Session(engine)

--- a/auacm/app/database.py
+++ b/auacm/app/database.py
@@ -1,4 +1,4 @@
-'''Database handlers'''
+'''Database handlers.'''
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.ext.automap import automap_base

--- a/auacm/app/modules/user_manager/models.py
+++ b/auacm/app/modules/user_manager/models.py
@@ -1,7 +1,11 @@
-from app import Base
+'''Reflection and utilities for the users database table.'''
+
+from app.database import Base, session
+from app.util import login_manager
 
 class User(Base.classes.users):
-    
+    '''Model object for entries in the users database table.'''
+
     def __init__(self, user):
         self.user = user
     
@@ -16,3 +20,13 @@ class User(Base.classes.users):
     
     def get_id(self):
         return self.user.username
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    '''Log a user into the app.'''
+    result = session.query(Base.classes.users).filter(Base.classes.users.username==user_id).first()
+    if result:
+        return User(result)
+    else:
+        return None

--- a/auacm/app/util.py
+++ b/auacm/app/util.py
@@ -1,0 +1,29 @@
+'''Utility functions and objects for the auacm server.'''
+
+from flask import send_from_directory, jsonify
+from flask.ext.login import LoginManager
+from flask.ext.bcrypt import Bcrypt
+from app import app
+
+# bcrypt setup
+bcrypt = Bcrypt(app)
+
+
+# login session setup
+login_manager = LoginManager()
+login_manager.init_app(app)
+
+
+def serve_html(filename):
+    '''Serve static HTML pages.'''
+    return send_from_directory(app.static_folder+"/html/", filename)
+
+
+def serve_response(response, response_code=200):
+    '''Serve json containing a response to a request.'''
+    return jsonify({'status': response_code, 'data': response}), response_code
+
+
+def serve_error(error, response_code):
+    '''Serve an error in response to a request.'''
+    return jsonify({'status': response_code, 'error': error}), response_code

--- a/auacm/app/views.py
+++ b/auacm/app/views.py
@@ -1,14 +1,10 @@
-from flask import render_template, jsonify, request
+from flask import render_template, request
 from flask.ext.login import login_user, logout_user, current_user, login_required
-from app import app, session, Base, serve_html, load_user, bcrypt
-from app.modules.user_manager.models import User
+from app import app
+from app.modules.user_manager.models import User, load_user
+from app.util import bcrypt, login_manager, serve_html, serve_response, serve_error
 # from app.modules.problem_manager.models import Problem
 
-def serve_response(response, response_code=200):
-    return jsonify({'status': response_code, 'data': response}), response_code
-
-def serve_error(error, response_code):
-    return jsonify({'status': response_code, 'error': error}), response_code
 
 @app.route('/')
 @app.route('/index')


### PR DESCRIPTION
Detailed changes:
- create database module.  This will allow us to change the database with sqlalchemy without having to spin up the server.
- create util module.  This contains utility functions and entities -- bcrypt, login management, and functions for serving static content, templated html and the like can live here.
- fix the dirty static html hack from stack overflow to use a builtin flask function.
- move login function to the user models.py module.  We had to import that module in the middle of the **init** code to get it working there, and since its purpose is to log a user in from the database, this seems like a more reasonable home for it.
