### PR TITLE
Maintenance -- Ubuntu setup script fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Do this by executing the following commands:
 
     ``$ ./run.py``
     
-More steps to come.
+8. Navigate to the setup folder.
+
+9. Copy data.zip to auacm/app/data.zip and extract the contents
+   there. You should now have two folders inside auacm/app/data/,
+   problems and submits.
 
 ##Ubuntu
 
@@ -53,23 +57,17 @@ More steps to come.
 
     ``git clone https://github.com/AuburnACM/AUACM.git ``
 
-2. Navigate to ``.../AUACM/auacm/`` and execute this to setup the environment:
+2. Navigate to ``.../AUACM/setup/`` and execute this to setup the environment:
     
-    ``source ubuntu_setup.env``
+    ``sh ubuntu_setup.sh``
     
     Follow all the setup instructions.
 
 3. Now you can run the server on localhost:5000 by running
+    
+    ``$ cd ../auacm``
+
     ``$ ./run.py``
-
-
-## Everyone
-
-1. Navigate to the setup folder.
-
-2. Copy data.zip to auacm/app/data.zip and extract the contents
-   there. You should now have two folders inside auacm/app/data/,
-   problems and submits.
    
 # Need test solutions or competitions?
 ## We've got you covered.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Do this by executing the following commands:
 
 2. Navigate to ``.../AUACM/setup/`` and execute this to setup the environment:
     
-    ``sh ubuntu_setup.sh``
+    ``$ sh ubuntu_setup.sh``
     
     Follow all the setup instructions.
 

--- a/auacm/ubuntu_setup.env
+++ b/auacm/ubuntu_setup.env
@@ -1,6 +1,0 @@
-cd setup
-sudo ./ubuntu_dependencies.sh
-source ./initialize_virtualenv.env
-sudo ./initialize_database.sh
-cd ..
-echo "Setup complete!  You should now be able to launch the server."

--- a/setup/initialize_database.sh
+++ b/setup/initialize_database.sh
@@ -1,2 +1,9 @@
+#!/bin/sh
 echo "Setting up mysql database."
-mysql -uroot < acm.sql
+sudo mysql -uroot < acm.sql
+echo "Setting up submissions and problems data."
+mkdir ../auacm/app/data
+cp data.zip ../auacm/app/data/data.zip
+cd ../auacm/app/data
+unzip data.zip
+rm data.zip

--- a/setup/initialize_virtualenv.sh
+++ b/setup/initialize_virtualenv.sh
@@ -1,7 +1,9 @@
+#!/bin/sh
 echo "Setting up virtualenv."
 pip install virtualenv
-virtualenv ../flask
-../flask/bin/pip install -r ../requirements.txt
+cd ../auacm/
+virtualenv flask
+flask/bin/pip install -r requirements.txt
 echo "Setting up nodejs and bower."
 npm install bower
 bower install

--- a/setup/ubuntu_dependencies.sh
+++ b/setup/ubuntu_dependencies.sh
@@ -1,8 +1,11 @@
+#!/bin/sh
 echo "Installing dependencies."
 sudo apt-get install python-dev
 sudo apt-get install libffi-dev
-sudo apt-get install node
+sudo apt-get install nodejs
+sudo apt-get install nodejs-legacy
+sudo apt-get install npm
 sudo apt-get install mysql-server
 sudo apt-get install libmysqlclient-dev
-sudo apt-get install npm
+sudo apt-get install build-essential
 echo "Dependencies installed."

--- a/setup/ubuntu_setup.sh
+++ b/setup/ubuntu_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo "This script will set up AUACM."
+sudo sh ubuntu_dependencies.sh
+sh initialize_database.sh
+sh initialize_virtualenv.sh
+echo "Setup complete!  You should now be able to launch the server."
+echo "To get started execute $ cd ../auacm && ./run.py to get started"


### PR DESCRIPTION
- Make the setup scripts work out of the setup folder
- Fix problems with bower dependency setup (node and nodejs are two different apt repositories, which breaks things.)
- Add a script that takes care of unzipping the files.

I'd imagine that everything except the dependency installation also works on Mac.  I'll test and see if I can make it work.  If so, I'll add OSX setup scripts.
