### PR TITLE
Fix crashes from string encoding and database column limit

### DIFF
--- a/auacm/app/modules/problem_manager/views.py
+++ b/auacm/app/modules/problem_manager/views.py
@@ -129,7 +129,7 @@ def create_problem():
     try:
         # Convert the JSON to python array of dictionaries
         cases = request.form['cases']
-        cases = loads(str(cases))
+        cases = loads(cases)
         for case in cases:
             if 'input' not in case or 'output' not in case:
                 return serve_error(
@@ -297,7 +297,7 @@ def update_problem(identifier):    # pylint: disable=too-many-branches
             database.session.flush()
             database.session.commit()
         case_num = 1
-        cases = loads(str(request.form['cases']))
+        cases = loads(request.form['cases'])
         for case in cases:
             SampleCase(
                 pid=pid,

--- a/setup/acm.sql
+++ b/setup/acm.sql
@@ -203,8 +203,8 @@ DROP TABLE IF EXISTS `sample_cases`;
 CREATE TABLE `sample_cases` (
   `pid` int(32) NOT NULL DEFAULT '0',
   `case_num` int(11) NOT NULL DEFAULT '0',
-  `input` varchar(255) DEFAULT NULL,
-  `output` varchar(255) DEFAULT NULL,
+  `input` text,
+  `output` text,
   PRIMARY KEY (`pid`,`case_num`),
   CONSTRAINT `sample_cases_ibfk_1` FOREIGN KEY (`pid`) REFERENCES `problems` (`pid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Okay, so I was trying to submit a problem and I got [this error](https://gist.github.com/WilliamHester/571d3882c7dfc24ced58). Eventually, I boiled it down to our casting of `request.form['cases']` to a string type. After removing the cast, I ran into a separate yet related issue where the column only allowed for sample cases that were 255 characters or less, which was not enough for some of the old-style problems, since, technically, there's only one test case.
