### PR TITLE
Fix competitions time-related issues

### DIFF
--- a/auacm/app/static/html/competitions.html
+++ b/auacm/app/static/html/competitions.html
@@ -19,7 +19,7 @@
       <tr ng-repeat="competition in competitions.ongoing">
         <td><a href="/#/competitions/{{ competition.cid }}">{{ competition.name }}</a></td>
         <td>{{ getRemainingTime(competition) | secondsToDateTime | date:"h:mm:ss" }}</td>
-        <td>{{ competition.length | secondsToDateTime | date:"h:mm:ss" }}</td>
+        <td>{{ competition.length | secondsToHours | date:"h:mm:ss" }}</td>
         <td>{{ competition.startTime | secondsToDateTime | date:"medium" }}</td>
         <td>
           <div ng-if="competition.registered">Registered</div>
@@ -41,7 +41,7 @@
       </tr>
       <tr ng-repeat="competition in competitions.upcoming">
         <td><a href="/#/competitions/{{ competition.cid }}">{{ competition.name }}</a></td>
-        <td>{{ competition.length | secondsToDateTime | date:"h:mm:ss" }}</td>
+        <td>{{ competition.length | secondsToHours | date:"h:mm:ss" }}</td>
         <td>{{ competition.startTime | secondsToDateTime | date:"medium" }}</td>
         <td>
           <div ng-if="competition.registered">Registered</div>
@@ -62,7 +62,7 @@
       </tr>
       <tr ng-repeat="competition in competitions.past">
         <td><a href="/#/competitions/{{ competition.cid }}">{{ competition.name }}</a></td>
-        <td>{{ competition.length | secondsToDateTime | date:"h:mm:ss" }}</td>
+        <td>{{ competition.length | secondsToHours | date:"h:mm:ss" }}</td>
         <td>{{ competition.startTime | secondsToDateTime | date:"medium" }}</td>
       </tr>
     </table>

--- a/auacm/app/static/html/scoreboard.html
+++ b/auacm/app/static/html/scoreboard.html
@@ -1,7 +1,7 @@
 <div>
   <div class="row">
     <h1 class="pull-left">{{ competition.name }}</h1>
-    <div ng-if="isAdmin && (active || !over)" class="dropdown pull-left margin-top margin-left">
+    <div ng-if="isAdmin && !ended" class="dropdown pull-left margin-top margin-left">
       <button class="btn btn-default dropdown-toggle" type="button"
           id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="true">

--- a/auacm/app/static/html/scoreboard.html
+++ b/auacm/app/static/html/scoreboard.html
@@ -1,7 +1,7 @@
 <div>
   <div class="row">
     <h1 class="pull-left">{{ competition.name }}</h1>
-    <div ng-if="isAdmin && active" class="dropdown pull-left margin-top margin-left">
+    <div ng-if="isAdmin && (active || !over)" class="dropdown pull-left margin-top margin-left">
       <button class="btn btn-default dropdown-toggle" type="button"
           id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="true">
@@ -13,7 +13,7 @@
         <li><a href="/#/competitions/{{ cid }}/teams">Teams</a></li>
       </ul>
     </div>
-    <h2 class="pull-right" ng-show="active">{{ timeLeft | secondsToDateTime | date:"H:mm:ss" }}</h2>
+    <h2 class="pull-right" ng-show="active || !ended">{{ timeLeft | secondsToHours | date:"H:mm:ss" }}</h2>
   </div>
   <div class="body">
     <table class="table table-bordered">
@@ -23,7 +23,7 @@
           <th>Team</th>
           <th>Solved</th>
           <th>Time</th>
-          <th ng-repeat="name in problemNames"><a href="/#/problems/{{ compProblems[name].shortname }}">{{ name }}</a></th>
+          <th ng-if="active || ended" ng-repeat="name in problemNames"><a href="/#/problems/{{ compProblems[name].shortname }}">{{ name }}</a></th>
         </tr>
       </thead>
       <tr ng-repeat="team in teams | orderBy:['-solved', 'time']">
@@ -31,7 +31,7 @@
         <td>{{ team.name }}</td>
         <td>{{ team.solved }}</td>
         <td>{{ team.time }}</td>
-        <td ng-repeat="name in problemNames"
+        <td ng-if="active || ended" ng-repeat="name in problemNames"
             ng-class="{'success': team.problemData[compProblems[name].pid].status === 'correct',
                     'danger': team.problemData[compProblems[name].pid].status === 'incorrect'}">
             <div ng-hide="team.problemData[compProblems[name].pid].status === 'unattempted'">

--- a/auacm/app/static/js/controllers/EditCompetitionController.js
+++ b/auacm/app/static/js/controllers/EditCompetitionController.js
@@ -10,7 +10,9 @@ app.controller('EditCompetitionController', ['$scope', '$http', '$location',
             .then(function(response) {
                 competition = response.data.data.competition;
 
-                var date = new Date(competition.startTime * 1000);
+                var offset = Date.now().getTimezoneOffset() / 1000;
+                console.log(offset);
+                var date = new Date(competition.startTime * 1000 + offset);
                 var startTime = '';
                 startTime += (date.getMonth() + 1) + '-' + date.getDate() +
                         '-' + date.getFullYear();

--- a/auacm/app/static/js/controllers/EditCompetitionController.js
+++ b/auacm/app/static/js/controllers/EditCompetitionController.js
@@ -10,9 +10,7 @@ app.controller('EditCompetitionController', ['$scope', '$http', '$location',
             .then(function(response) {
                 competition = response.data.data.competition;
 
-                var offset = Date.now().getTimezoneOffset() / 1000;
-                console.log(offset);
-                var date = new Date(competition.startTime * 1000 + offset);
+                var date = new Date(competition.startTime * 1000);
                 var startTime = '';
                 startTime += (date.getMonth() + 1) + '-' + date.getDate() +
                         '-' + date.getFullYear();

--- a/auacm/app/static/js/modules/mainModule.js
+++ b/auacm/app/static/js/modules/mainModule.js
@@ -90,6 +90,12 @@ app.config(function($routeProvider) {
 
 app.filter('secondsToDateTime', [function() {
     return function(seconds) {
+        return new Date(seconds * 1000);
+    };
+}]);
+
+app.filter('secondsToHours', [function() {
+    return function(seconds) {
         return new Date(1970, 0, 1).setSeconds(seconds);
     };
 }]);


### PR DESCRIPTION
I didn't mean to do two things at once here, but I did. I fixed the issue of competitions displaying the incorrect start time and also fixed the issue if competitions not starting the timer when the competition started. While I was there, I went ahead and cleaned up the code that displays the timer and added variables to denote different states of the competition, `active`, as in "ongoing", and `ended`. This enabled me to hide the problems before the competition started on the scoreboard page, showing them once the clock starts ticking.

Fixes #55 
