### PR TITLE
Fixes for judge tests

### DIFF
--- a/auacm/app/modules/submission_manager/judge.py
+++ b/auacm/app/modules/submission_manager/judge.py
@@ -19,7 +19,7 @@ COMPILE_COMMAND = {
 }
 RUN_COMMAND = {
     'java': 'java -cp {0}/ {1}',
-    'py': 'python {0}/{1}.py',
+    'py': 'python2.7 {0}/{1}.py',
     'py3': 'python3 {0}/{1}.py',
     'c': '{0}/{1}',
     'cpp': '{0}/{1}',

--- a/auacm/app/modules/submission_manager/judge_test.py
+++ b/auacm/app/modules/submission_manager/judge_test.py
@@ -75,6 +75,9 @@ class JudgeTest(object):
         )
         file_path = os.path.join(
             data_folder, 'problems', problem, 'solutions', filename)
+        submit_directory = os.path.join(app.config['DATA_FOLDER'], 'submits', str(submit.job))
+        if not os.path.exists(submit_directory):
+            os.mkdir(submit_directory)
         # Keep track of submit_file so that we can close it.
         self.submit = submit
         self.submit_file = MockUploadFile(file_path)
@@ -88,6 +91,9 @@ class JudgeTest(object):
             Normally one of the constants exposed by the judge module.
         :return: None
         """
+        directory = judge.directory_for_submission(self.submit)
+        self.submit_file.save(
+                os.path.join(directory, self.submit_file.filename))
         self.assertEqual(
             expected_result,
             judge.evaluate(self.submit, self.submit_file, 1))
@@ -102,7 +108,6 @@ class JudgeTest(object):
         :return: None
         """
         directory = judge.directory_for_submission(self.submit)
-        os.makedirs(directory)
         self.submit_file.save(
             os.path.join(directory, self.submit_file.filename))
         self.assertEqual(


### PR DESCRIPTION
As part of the upgrade to Python 3, the code to save files
inside the judge module was moved to the main thread. The
unit tests, however, broke because they relied on this
functionality. This commit puts the file saving in the tests
themselves, fixing the tests.
