### PR TITLE
Change socket use, clean up Scoreboard html

### DIFF
--- a/auacm/app/modules/competition_manager/views.py
+++ b/auacm/app/modules/competition_manager/views.py
@@ -191,9 +191,6 @@ def get_competition_data(cid):
         team_row['problemData'] = team_problems
         scoreboard.append(team_row)
 
-    # Send the system time to the client
-    Flasknado.emit('system_time', {'milliseconds': int(time() * 1000)})
-
     return serve_response({
         'competition': competition.to_dict(),
         'compProblems': comp_problems,

--- a/auacm/app/modules/flasknado/flasknado.py
+++ b/auacm/app/modules/flasknado/flasknado.py
@@ -1,4 +1,6 @@
 from tornado.websocket import WebSocketHandler
+from json import loads
+from time import time
 
 def make_flasknado():
     """ Creates a new class instance of Flasknado
@@ -24,12 +26,16 @@ class Flasknado(WebSocketHandler):
     clients = []  # initialize the list of clients to an empty list
 
     @classmethod
+    def wrap(self, event_type, data):
+        return {
+            'eventType': event_type,
+            'data': data
+        }
+
+    @classmethod
     def emit(self, event_type, data):
         for client in self.clients:
-            client.write_message({
-                'eventType': event_type,
-                'data': data
-            })
+            client.write_message(self.wrap(event_type, data))
 
     def open(self):
         Flasknado.clients.append(self)
@@ -38,7 +44,11 @@ class Flasknado(WebSocketHandler):
         Flasknado.clients.remove(self)
 
     def on_message(self, message):
-        pass
+        data = loads(message)
+        if data['eventType'] == 'system_time':
+            self.write_message(self.wrap('system_time', {
+                'milliseconds': int(time() * 1000)
+            }))
 
     def data_received(self, data):
         pass

--- a/auacm/app/static/html/scoreboard.html
+++ b/auacm/app/static/html/scoreboard.html
@@ -1,26 +1,25 @@
 <div>
   <div class="row">
     <h1 class="pull-left">{{ competition.name }}</h1>
-    <div ng-if="isAdmin && !ended" class="dropdown pull-left margin-top margin-left">
+    <div ng-if="isAdmin && !ended" class="dropdown pull-left margin-top margin-left" uib-dropdown>
       <button class="btn btn-default dropdown-toggle" type="button"
           id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true"
-          aria-expanded="true">
+          aria-expanded="true" uib-dropdown-toggle>
         Manage
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" uib-dropdown-menu>
         <li><a href="/#/competitions/{{ cid }}/edit">Edit</a></li>
         <li><a href="/#/competitions/{{ cid }}/teams">Teams</a></li>
       </ul>
     </div>
     <h2 class="pull-right" ng-show="active || !ended">{{ timeLeft | secondsToHours | date:"H:mm:ss" }}</h2>
   </div>
-  <div class="row" ng-show="!active && !ended">
-    <div class="col-md-4 col-md-offset-4 text-center bg-info">
-      <h3>Time Until Start: {{ timeUntil | secondsToHours | date:"H:mm:ss" }}</h3>
-    </div>
+  <div class="col-md-8 col-md-offset-2 jumbotron" ng-if="!active && !ended">
+    <h1>Hang on!</h1>
+    <p>The competition will start in {{ timeUntil | secondsToHours | date:"H:mm:ss" }}.</p>
   </div>
-  <div class="body">
+  <div class="body" ng-show="active || ended">
     <table class="table table-bordered">
       <thead>
         <tr>
@@ -28,7 +27,7 @@
           <th>Team</th>
           <th>Solved</th>
           <th>Time</th>
-          <th ng-if="active || ended" ng-repeat="name in problemNames"><a href="/#/problems/{{ compProblems[name].shortname }}">{{ name }}</a></th>
+          <th ng-repeat="name in problemNames"><a href="/#/problems/{{ compProblems[name].shortname }}">{{ name }}</a></th>
         </tr>
       </thead>
       <tr ng-repeat="team in teams | orderBy:['-solved', 'time']">

--- a/auacm/app/static/js/controllers/ScoreboardController.js
+++ b/auacm/app/static/js/controllers/ScoreboardController.js
@@ -14,6 +14,7 @@ app.controller('ScoreboardController', ['$scope', '$http', '$routeParams',
         // The server is *ahead* of the client by offset milliseconds
         offset = -Date.now() + event.milliseconds;
     });
+    $scope.socket.send('system_time'); // request the offset
 
     var genScoreboard = function() {
         var team, i;

--- a/auacm/app/static/js/sockets.js
+++ b/auacm/app/static/js/sockets.js
@@ -1,14 +1,18 @@
 function Socket(url) {
-    var ws = new WebSocket(url);
+    this.ws = new WebSocket(url);
     this.events = {};
     var parent = this;
     this.on = function(event, func) {
         parent.events[event] = func;
     };
-    ws.onmessage = function(event) {
+    this.ws.onmessage = function(event) {
         var data = JSON.parse(event.data);
         if (data.eventType in parent.events) {
             parent.events[data.eventType](data.data);
         }
+    };
+    this.send = function(type, data) {
+        var string = JSON.stringify({'eventType': type, 'data': data});
+        parent.ws.send(string);
     };
 }


### PR DESCRIPTION
Since Flasknado.emit() sent a message to _all_ clients, it meant that
every single client would receive a new offset every time a client
requested the offset from the server. It seemed like overkill. Instead,
the websockets can now be used to request the time from the server.
Also, the time until the competition starts is now displayed in
Bootstrap's 'jumbotron' class and the table is hidden until the
competition starts. The only downside is that now teams are not visible
until the competition starts.
