### PR TITLE
Fix license boilerplate

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,14 @@
+Copyright 2015-2016 William Hester, Drew Hoover, Brandon Morris,
+Mitchell Price, and David Shuckerow.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this program or its source code except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -174,29 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-


### PR DESCRIPTION
I'm guessing the boilerplate text was left at the end of the license by accident.  :)

Somewhere you need to state who actually owns the copyright.  Since you guys have been doing this as a personal project (not a work for hire), you personally own the copyright.  I just listed everyone in the Git log.

Many open source projects include a copyright header at the top of every single source file.  That's probably overkill here, but you should definitely state it somewhere.

Sorry for not contributing something more useful.
