### PR TITLE
Competition tests

### DIFF
--- a/auacm/app/modules/competition_manager/competition_test.py
+++ b/auacm/app/modules/competition_manager/competition_test.py
@@ -1,6 +1,6 @@
 """Tests for AUACM competition manager"""
 
-import unittest, json
+import json, time
 
 from app import app, test_app
 from app.util import AUACMTest
@@ -9,13 +9,37 @@ from app.modules.competition_manager.models import Competition, CompProblem, Com
 import app.database as database
 session = database.session
 
+TEST_COMP = {
+    
+}
 
 class AUACMCompetitionTests(AUACMTest):
     """Test cases for the AUACM competition manager"""
 
     def testCreate(self):
         """Test creating a new competition"""
-        pass
+        self.login()
+        post_form = {
+            'name': 'Test Competition',
+            'start_time': int(time.time()),
+            'problems': '[{"label": "A", "pid": 1}]',
+            'closed': False,
+            'length': 10,
+        }
+
+        response = json.loads(test_app.post('/api/competitions',
+                              data=post_form).data.decode())
+
+        self.assertEqual(200, response['status'])
+
+        cid = response['data']['cid']
+        comp = (session.query(Competition)
+            .filter_by(cid=cid).
+            first()
+        )
+        self.assertIsNotNone(comp)
+        session.delete(comp)
+        session.commit()
 
     def testGetOne(self):
         """Test retrieving a single competition by id"""
@@ -32,3 +56,5 @@ class AUACMCompetitionTests(AUACMTest):
     def testDelete(self):
         """Test deleting a competition"""
         pass
+
+    

--- a/auacm/app/modules/competition_manager/competition_test.py
+++ b/auacm/app/modules/competition_manager/competition_test.py
@@ -16,7 +16,7 @@ TEST_COMP = {
 class AUACMCompetitionTests(AUACMTest):
     """Test cases for the AUACM competition manager"""
 
-    def testCreate(self):
+    def testCreateComp(self):
         """Test creating a new competition"""
         self.login()
         post_form = {
@@ -38,23 +38,75 @@ class AUACMCompetitionTests(AUACMTest):
             first()
         )
         self.assertIsNotNone(comp)
+
+        comp_problems = session.query(CompProblem).filter_by(cid=cid).all()
+        for comp_problem in comp_problems:
+            session.delete(comp_problem)
         session.delete(comp)
         session.commit()
 
-    def testGetOne(self):
+    def testGetOneComp(self):
         """Test retrieving a single competition by id"""
-        pass
+        competition = self._insert_comp_into_db()[0]
 
-    def testGetAll(self):
+        response = test_app.get('/api/competitions/{}'.format(competition.cid))
+        self.assertIsNotNone(response)
+        self.assertEqual(200, response.status_code)
+        response_body = json.loads(response.data.decode())['data']
+
+        print(json.dumps(response_body, indent=4))
+        self.assertEqual(competition.cid, response_body['competiton']['cid'])
+
+        session.delete(competition)
+        session.commit()
+
+    def testGetAllComp(self):
         """Test retrieving all competitions"""
         pass
 
-    def testEdit(self):
+    def testEditComp(self):
         """Test modifying a competition"""
         pass
 
-    def testDelete(self):
+    def testDeleteComp(self):
         """Test deleting a competition"""
         pass
 
-    
+    def testGetCompTeams(self):
+        """Test retreiving the teams for a competition"""
+        pass
+
+    def testEditCompTeams(self):
+        """Test editing the teams for a competition"""
+        pass
+
+    def _insert_comp_into_db(self, num=1):
+        """
+        Inserts a number of competitions into the database. The problems of
+        each competition are inserted as well, but those objects are not
+        returned.
+
+        :param num: the number of competitions to inser
+        :returns: a list of the new competition ORM objects
+        """
+        competitions = list()
+        for i in range(num):
+            competition = Competition(
+                name='Test Competition {}'.format(i),
+                start=int(time.time()),
+                stop=int(time.time()) + 10,
+                closed=0
+            )
+            cid = competition.commit_to_session(session)
+            session.add(
+                CompProblem(
+                    label='A',
+                    cid=cid,
+                    pid=1
+                )
+            )
+            competitions.append(competition)
+        session.commit()
+
+        return competitions
+

--- a/auacm/app/modules/competition_manager/competition_test.py
+++ b/auacm/app/modules/competition_manager/competition_test.py
@@ -1,0 +1,34 @@
+"""Tests for AUACM competition manager"""
+
+import unittest, json
+
+from app import app, test_app
+from app.util import AUACMTest
+from app.modules.competition_manager.models import Competition, CompProblem, CompUser
+
+import app.database as database
+session = database.session
+
+
+class AUACMCompetitionTests(AUACMTest):
+    """Test cases for the AUACM competition manager"""
+
+    def testCreate(self):
+        """Test creating a new competition"""
+        pass
+
+    def testGetOne(self):
+        """Test retrieving a single competition by id"""
+        pass
+
+    def testGetAll(self):
+        """Test retrieving all competitions"""
+        pass
+
+    def testEdit(self):
+        """Test modifying a competition"""
+        pass
+
+    def testDelete(self):
+        """Test deleting a competition"""
+        pass

--- a/auacm/app/modules/competition_manager/competition_test.py
+++ b/auacm/app/modules/competition_manager/competition_test.py
@@ -9,9 +9,6 @@ from app.modules.competition_manager.models import Competition, CompProblem, Com
 import app.database as database
 session = database.session
 
-TEST_COMP = {
-    
-}
 
 class AUACMCompetitionTests(AUACMTest):
     """Test cases for the AUACM competition manager"""
@@ -54,31 +51,127 @@ class AUACMCompetitionTests(AUACMTest):
         self.assertEqual(200, response.status_code)
         response_body = json.loads(response.data.decode())['data']
 
-        print(json.dumps(response_body, indent=4))
-        self.assertEqual(competition.cid, response_body['competiton']['cid'])
+        self.assertEqual(competition.cid, response_body['competition']['cid'])
+        self.assertIn('compProblems', response_body)
+        self.assertIn('competition', response_body)
+        self.assertIn('teams', response_body)
+        self.assertEqual(competition.to_dict(), response_body['competition'])
 
         session.delete(competition)
         session.commit()
 
     def testGetAllComp(self):
         """Test retrieving all competitions"""
-        pass
+        competitions = self._insert_comp_into_db(3)
+
+        response = test_app.get('/api/competitions')
+        response_body = json.loads(response.data.decode())['data']
+
+        self.assertEqual(200, response.status_code)
+        all_comps = (response_body['ongoing'] + response_body['upcoming'] +
+                     response_body['past'])
+        for competition in competitions:
+            self.assertIn(
+                competition.to_dict(),
+                all_comps
+            )
+
+        for competition in competitions:
+            session.delete(competition)
+        session.commit()
 
     def testEditComp(self):
         """Test modifying a competition"""
-        pass
+        self.login()
+        competition = self._insert_comp_into_db()[0]
+        competition_data = {
+            'name':  'Different Name',
+            'start_time': int(time.time()),
+            'length': 100,
+            'closed': False,
+            'problems': '[{"label": "A", "pid": 1}]',
+        }
+
+        response = test_app.put('/api/competitions/{}'.format(competition.cid),
+                                data=competition_data)
+
+        self.assertEqual(200, response.status_code)
+        response_data = json.loads(response.data.decode())['data']
+        self.assertEqual(competition_data['name'], response_data['name'])
+        self.assertEqual(competition_data['start_time'],
+                         response_data['startTime'])
+        self.assertEqual(competition_data['length'], response_data['length'])
+
+        session.delete(competition)
+        session.commit()
 
     def testDeleteComp(self):
         """Test deleting a competition"""
-        pass
+        self.login()
+        competition = self._insert_comp_into_db()[0]
+        cid = competition.cid
+        session.expunge(competition)
+
+        response = test_app.delete('/api/competitions/{}'.format(cid))
+        self.assertEqual(204, response.status_code)
+        self.assertIsNone(session.query(Competition)
+                          .filter_by(cid=cid).first())
+
 
     def testGetCompTeams(self):
         """Test retreiving the teams for a competition"""
-        pass
+        competition = self._insert_comp_into_db()[0]
+        cid = competition.cid
+        user = CompUser(cid=cid, username=self.username, team='Team Test')
+        user.commit_to_session(session)
+
+        response = test_app.get('/api/competitions/{}/teams'.format(cid))
+        self.assertEqual(200, response.status_code)
+        response_data = json.loads(response.data.decode())['data']
+
+        self.assertIn('Team Test', response_data)
+        self.assertEqual(
+            self.username,
+            response_data['Team Test'][0]['username']
+        )
+
+        session.delete(user)
+        session.delete(competition)
+        session.commit()
 
     def testEditCompTeams(self):
         """Test editing the teams for a competition"""
-        pass
+        self.login()
+        teams = {
+            'teams': json.dumps({
+                'Team Test Edited': [self.username]
+            })
+        }
+        competition = self._insert_comp_into_db()[0]
+        cid = competition.cid
+        session.add(
+            CompUser(
+                cid=cid,
+                username=self.username,
+                team='Team Test'
+            )
+        )
+        session.expunge(competition)
+        session.commit()
+
+        response = test_app.put('/api/competitions/{}/teams'.format(cid),
+                                 data=teams)
+        self.assertEqual(200, response.status_code)
+        response_body = json.loads(response.data.decode())['data']
+
+        self.assertEqual({}, response_body)
+        new_team = session.query(CompUser).filter_by(cid=cid).first()
+        self.assertEqual('Team Test Edited', new_team.team)
+        self.assertEqual(self.username, new_team.username)
+
+        session.delete(session.query(CompUser).filter_by(cid=cid).first())
+        session.delete(session.query(Competition).filter_by(cid=cid).first())
+        session.commit()
 
     def _insert_comp_into_db(self, num=1):
         """

--- a/auacm/app/modules/competition_manager/models.py
+++ b/auacm/app/modules/competition_manager/models.py
@@ -14,7 +14,7 @@ class Competition(Base):
             'registered': user_registered
         }
 
-    def commit_to_session(self):
+    def commit_to_session(self, session=session):
         """Commit this Competition to the database.
 
         This is useful for adding a newly-created Competition to the database.
@@ -33,7 +33,7 @@ class CompProblem(Base):
 class CompUser(Base):
     __tablename__ = 'comp_users'
 
-    def commit_to_session(self):
+    def commit_to_session(self, session=session):
         """Commit this CompUser to the database.
 
         This is useful for adding a newly-created CompUser to the database.

--- a/auacm/app/modules/competition_manager/models.py
+++ b/auacm/app/modules/competition_manager/models.py
@@ -24,6 +24,7 @@ class Competition(Base):
         session.commit()
         session.refresh(self)
         self._problem = None
+        return self.cid
 
 
 class CompProblem(Base):

--- a/auacm/app/modules/competition_manager/views.py
+++ b/auacm/app/modules/competition_manager/views.py
@@ -1,7 +1,6 @@
 from flask import request
 from flask.ext.login import current_user, login_required
 from app import app
-from app.database import session
 from app.util import serve_response, serve_error, admin_required
 from app.modules.flasknado.flasknado import Flasknado
 from .models import Competition, CompProblem, CompUser
@@ -11,6 +10,7 @@ from app.modules.user_manager.models import User
 from sqlalchemy import asc
 from time import time
 from json import loads
+import app.database as database
 
 
 @app.route('/api/competitions')
@@ -22,12 +22,12 @@ def get_competitions():
     registered = set()
 
     if not current_user.is_anonymous:
-        registered_rows = session.query(CompUser).filter(
+        registered_rows = database.session.query(CompUser).filter(
                 CompUser.username == current_user.username).all()
         for row in registered_rows:
             registered.add(row.cid)
 
-    for competition in session.query(Competition).all():
+    for competition in database.session.query(Competition).all():
         if competition.stop < current_time:
             past.append(competition.to_dict(
                 user_registered=competition.cid in registered))
@@ -55,25 +55,27 @@ def create_competition():
             stop=(int(data['start_time']) + int(data['length'])),
             closed=1 if bool(data['closed']) else 0
         )
-        competition.commit_to_session()
+        competition.commit_to_session(database.session)
 
         comp_problems = loads(data['problems'])
     except KeyError as err:
         return serve_error('You must specify name, startTime, length, and'
-                ' problem attributes. ' + err[0] + ' not found.',
-                response_code=400)
+                           ' problem attributes. ' + err[0] + ' not found.',
+                           response_code=400)
     except ValueError:
         return serve_error('JSON data for \'problems\' not properly formatted',
-                response_code=400)
+                           response_code=400)
 
     for problem in comp_problems:
-        session.add(CompProblem(
-            label=problem['label'][:2],
-            cid=competition.cid,
-            pid=problem['pid']
-        ))
-    session.flush()
-    session.commit()
+        database.session.add(
+            CompProblem(
+                label=problem['label'][:2],
+                cid=competition.cid,
+                pid=problem['pid']
+            )
+        )
+    database.session.flush()
+    database.session.commit()
 
     return serve_response(competition.to_dict())
 
@@ -93,18 +95,19 @@ def update_competition_data(cid):
     data = request.form
 
     try:
-        competition = session.query(Competition).filter(Competition.cid == cid)\
-                .first()
+        competition = database.session.query(Competition).filter(
+            Competition.cid == cid).first()
 
         competition.name = data['name']
         competition.start=int(data['start_time'])
         competition.stop=(int(data['start_time']) + int(data['length']))
         competition.closed = 0 if bool(data['closed']) else 0
-        competition.commit_to_session()
+        competition.commit_to_session(database.session)
 
         # If the client sends a PUT request, we need to delete all of the old
         # problems associated with this competition
-        session.query(CompProblem).filter(CompProblem.cid == cid).delete()
+        database.session.query(CompProblem).filter(
+            CompProblem.cid == cid).delete()
 
         comp_problems = loads(data['problems'])
     except KeyError as err:
@@ -116,39 +119,41 @@ def update_competition_data(cid):
                 response_code=400)
 
     for problem in comp_problems:
-        session.add(CompProblem(
+        database.session.add(CompProblem(
             label=problem['label'],
             cid=competition.cid,
             pid=problem['pid']
         ))
 
-    session.flush()
-    session.commit()
+    database.session.flush()
+    database.session.commit()
     return serve_response(competition.to_dict())
 
 
 @app.route('/api/competitions/<int:cid>')
 def get_competition_data(cid):
-    competition = session.query(Competition).filter(Competition.cid == cid).\
-            first()
+    competition = database.session.query(Competition).filter(
+        Competition.cid == cid).first()
     if competition is None:
         return serve_error('competition not found', response_code=404)
-    comp_users = session.query(CompUser).filter(CompUser.cid == cid).all()
+    comp_users = database.session.query(CompUser).filter(
+            CompUser.cid == cid).all()
 
     comp_problems = dict()
-    for prob in session.query(CompProblem, Problem).join(Problem).\
-            filter(CompProblem.cid == cid).all():
+    for prob in (database.session.query(CompProblem, Problem)
+                 .join(Problem).filter(CompProblem.cid == cid)
+                 .all()):
         comp_problems[prob.CompProblem.label] = {
             'pid': prob.Problem.pid,
             'name': prob.Problem.name,
             'shortname': prob.Problem.shortname
         }
 
-    submissions = session.query(Submission)\
-            .filter(Submission.submit_time > competition.start,\
-                    Submission.submit_time < competition.stop)\
-            .order_by(asc(Submission.submit_time))\
-            .all()
+    submissions = (database.session.query(Submission)
+                   .filter(Submission.submit_time > competition.start,
+                           Submission.submit_time < competition.stop)
+                   .order_by(asc(Submission.submit_time))\
+                   .all())
 
     scoreboard = list()
 
@@ -213,8 +218,8 @@ def register_for_competition(cid):
     listed. A 400 error will be returned if any of the users are already
     registered for the competition.
     """
-    if session.query(Competition).filter(Competition.cid == cid).first() \
-            is None:
+    if database.session.query(Competition).filter(
+         Competition.cid == cid).first() is None:
         return serve_error('Competition does not exist', response_code=404)
 
     if current_user.admin == 1 and 'users' in request.form:
@@ -227,18 +232,22 @@ def register_for_competition(cid):
         registrants = [current_user.username]
 
     for user in registrants:
-        if session.query(CompUser).filter(CompUser.cid == cid,
-            CompUser.username == user).first() is not None:
+        if database.session.query(CompUser).filter(
+            CompUser.cid == cid, CompUser.username == user
+            ).first() is not None:
             return serve_error('User ' + user + ' already registered for '
                     'competition', response_code=400)
 
     for username in registrants:
-        user = session.query(User).filter(User.username == user).first()
-        session.add(CompUser(
-            cid=cid,
-            username=user.username,
-            team=user.display
-        ))
+        user = database.session.query(User).filter(
+            User.username == user).first()
+        database.session.add(
+            CompUser(
+                cid=cid,
+                username=user.username,
+                team=user.display
+            )
+        )
         Flasknado.emit('new_user', {
             'cid': cid,
             'user': {
@@ -246,8 +255,8 @@ def register_for_competition(cid):
                 'username': user.username
             }
         })
-    session.flush()
-    session.commit()
+    database.session.flush()
+    database.session.commit()
 
     return serve_response({})
 
@@ -264,8 +273,8 @@ def unregister_for_competition(cid):
     Similar to the <code>/register</code> endpoint, an admin can post a list of
     users to unregister from the competition.
     """
-    if session.query(Competition).filter(Competition.cid == cid).first() \
-            is None:
+    if database.session.query(Competition).filter(
+        Competition.cid == cid).first() is None:
         return serve_error('Competition does not exist', response_code=404)
 
     if current_user.admin == 1 and 'users' in request.form:
@@ -278,11 +287,11 @@ def unregister_for_competition(cid):
         registrants = [current_user.username]
 
     for user in registrants:
-        (session.query(CompUser)
-                .filter(CompUser.username == user, CompUser.cid == cid)
-                .delete())
-    session.flush()
-    session.commit()
+        (database.session.query(CompUser)
+            .filter(CompUser.username == user, CompUser.cid == cid)
+            .delete())
+    database.session.flush()
+    database.session.commit()
 
     return serve_response({})
 
@@ -294,9 +303,11 @@ def get_competition_teams(cid):
 
     Returns all of the teams, their users, and those users' display names.
     """
-    comp_users = session.query(CompUser, User).join(User,
-            User.username == CompUser.username).filter(CompUser.cid == cid)\
-            .all()
+    comp_users = (database.session.query(CompUser, User)
+        .join(User, User.username == CompUser.username)
+        .filter(CompUser.cid == cid)
+        .all()
+    )
 
     teams = dict()
     for user in comp_users:
@@ -331,18 +342,20 @@ def put_competition_teams(cid):
                 response_code=400)
 
     # Delete all of the old CompUser rows for this competition
-    session.query(CompUser).filter(CompUser.cid == cid).delete()
+    database.session.query(CompUser).filter(CompUser.cid == cid).delete()
 
     for team in teams:
         for user in teams[team]:
-            session.add(CompUser(
-                cid=cid,
-                username=user,
-                team=team
-            ))
+            database.session.add(
+                CompUser(
+                    cid=cid,
+                    username=user,
+                    team=team
+                )
+            )
 
-    session.flush()
-    session.commit()
+    database.session.flush()
+    database.session.commit()
 
     return serve_response({})
 

--- a/auacm/app/util.py
+++ b/auacm/app/util.py
@@ -77,3 +77,25 @@ class AUACMTest(unittest.TestCase):
         """Log the test user out of the app"""
         response = json.loads(test_app.get('/api/logout').data.decode())
         assert 200 == response['status']
+
+    def insert_into_db(session, model, args_list):
+        """
+        Insert a number of ORM objects into the session for testing. The number
+        of objects inserted is equal to the length of the args_list parameter.
+
+        :param session: the database session to insert into
+        :param model: the model class of the objects to be added
+        :param args: a list of the arguments to pass to the model constructor
+        :param num: the number of ORM objects to create and insert
+        :returns: the list of new ORM objects
+        """
+        results = list()
+        for args in args_list:
+            model_object = model(**args)
+            session.add(model_object)
+            session.flush()
+            session.commit(self)
+            session.refresh(model_object)
+            results.append(model_object)
+
+        return results


### PR DESCRIPTION
### Changes
- General smoke tests for competition CRUD-ing
  - **Not** meant to be full-featured tests, just general indications that API endpoints aren't _completely_ broken
- Add `DELETE` endpoint for specific competitions (`/api/competitions/<int:cid>`)
#### Further considerations
- These tests, in reality, barely scratch the surface. Not sure what kind of code coverage we're shooting for, but this is minimal

**Note** This PR includes changes from #88, which should be merged first
