### PR TITLE
Problem comp release

### DIFF
--- a/auacm/app/modules/problem_manager/views.py
+++ b/auacm/app/modules/problem_manager/views.py
@@ -23,10 +23,10 @@ from time import time
 @app.route('/problems/<shortname>/info.pdf', methods=['GET'])
 def get_problem_info(shortname):
     """Serve the PDF description of a problem"""
-    pid = database.session.query(Problem).\
-            options(load_only('pid', 'shortname')).\
-            filter(Problem.shortname == shortname).\
-            first().pid
+    pid = (database.session.query(Problem)
+           .options(load_only('pid', 'shortname'))
+           .filter(Problem.shortname == shortname)
+           .first().pid)
     return serve_info_pdf(str(pid))
 
 
@@ -80,10 +80,10 @@ def get_problems():
     solved_set = set()
 
     if not current_user.is_anonymous:
-        solved = database.session.query(Submission).\
-                filter(Submission.username == current_user.username).\
-                filter(Submission.result == "good").\
-                all()
+        solved = (database.session.query(Submission)
+                  .filter(Submission.username == current_user.username)
+                  .filter(Submission.result == "good")
+                  .all())
         for solve in solved:
             solved_set.add(solve.pid)
 
@@ -201,16 +201,16 @@ def delete_problem(identifier):
         pid = problem.pid
 
     # Delete from problem_data table first to satisfy foreign key constraint
-    problem_data = database.session.query(ProblemData).\
-        filter(ProblemData.pid == pid)
+    problem_data = (database.session.query(ProblemData)
+                    .filter(ProblemData.pid == pid))
     if not problem_data.first():
         return serve_error('Could not find problem data with pid ' +
                            pid, response_code=401)
     database.session.delete(problem_data.first())
 
     # Delete any and all sample cases associated w/ problem
-    for case in database.session.query(SampleCase).\
-            filter(SampleCase.pid == pid).all():
+    for case in (database.session.query(SampleCase)
+                 .filter(SampleCase.pid == pid).all()):
         database.session.delete(case)
 
     # Delete from problem table
@@ -263,8 +263,8 @@ def update_problem(identifier):    # pylint: disable=too-many-branches
     # If sample cases were uploaded, delete cases and go with the new ones
     case_lst = list()
     if 'cases' in request.form:
-        for old_case in database.session.query(SampleCase).\
-                filter(SampleCase.pid == pid).all():
+        for old_case in (database.session.query(SampleCase)
+                         .filter(SampleCase.pid == pid).all()):
             database.session.delete(old_case)
             database.session.flush()
             database.session.commit()

--- a/auacm/app/modules/problem_manager/views.py
+++ b/auacm/app/modules/problem_manager/views.py
@@ -47,7 +47,7 @@ def get_problem(identifier):
 
     # Hide unreleased problems to non-admins
     if problem is None or (current_user.admin != 1 and comp_not_released(
-            problem.Problem.comp_release)
+            problem.Problem.comp_release)):
         return serve_error('404: Problem Not Found', 404)
 
     cases = list()

--- a/auacm/app/modules/problem_manager/views.py
+++ b/auacm/app/modules/problem_manager/views.py
@@ -78,6 +78,9 @@ def get_problems():
     """Obtain basic information of all the problems in the database"""
     problems = list()
     solved_set = set()
+    competitions = dict()
+    for comp in database.session.query(Competition).all():
+        competitions[comp.cid] = comp.start
 
     if not current_user.is_anonymous:
         solved = (database.session.query(Submission)
@@ -87,18 +90,20 @@ def get_problems():
         for solve in solved:
             solved_set.add(solve.pid)
 
+    now = time()
     for problem in database.session.query(Problem).all():
-        problems.append({
-            'pid': problem.pid,
-            'name': problem.name,
-            'shortname': problem.shortname,
-            'appeared': problem.appeared,
-            'difficulty': problem.difficulty,
-            'comp_release': problem.comp_release,
-            'added': problem.added,
-            'solved': problem.pid in solved_set,
-            'url': url_for_problem(problem)
-        })
+        if problem.comp_release and competitions[problem.comp_release] < now:
+            problems.append({
+                'pid': problem.pid,
+                'name': problem.name,
+                'shortname': problem.shortname,
+                'appeared': problem.appeared,
+                'difficulty': problem.difficulty,
+                'comp_release': problem.comp_release,
+                'added': problem.added,
+                'solved': problem.pid in solved_set,
+                'url': url_for_problem(problem)
+            })
 
     problems.sort(key=lambda x: x['name'])
     return serve_response(problems)

--- a/auacm/app/static/html/editProblem.html
+++ b/auacm/app/static/html/editProblem.html
@@ -93,6 +93,18 @@
             ng-model="current_prob.difficulty">
         </div>
 
+        <!-- Competition Release -->
+        <div class="form-group">
+          <label for="comp_release"
+                 uib-tooltip="Hide this problem until the competition starts">
+            Release with competition:
+          </label>
+          <select ng-model="current_prob.comp_release"
+                  ng-options="comp.cid as comp.name for comp in competitions">
+            <option value="">Select Competition</option>
+          </select>
+        </div>
+
         <!-- Submit Button -->
         <button type="submit" class="btn btn-primary"
           ng-click="save()">Save Changes</button>

--- a/auacm/app/static/js/controllers/EditProblemController.js
+++ b/auacm/app/static/js/controllers/EditProblemController.js
@@ -75,7 +75,7 @@ app.controller('EditProblemController', ['$scope', '$route', '$http',
             fd.append('sol_file', $scope.solFile);
         if (typeof prob.appeared !== 'undefined')
             fd.append('appeared_in', prob.appeared);
-        if (typeof prob.comp_release !== 'undefined');
+        if (typeof prob.comp_release !== 'undefined')
             fd.append('comp_release', parseInt(prob.comp_release));
 
         $http({

--- a/auacm/app/static/js/controllers/EditProblemController.js
+++ b/auacm/app/static/js/controllers/EditProblemController.js
@@ -40,6 +40,16 @@ app.controller('EditProblemController', ['$scope', '$route', '$http',
         }
     };
 
+    // Get all the competitions
+    // TODO: Wrap in a service or $resource
+    $http.get('/api/competitions')
+        .then(function(response) {
+            $scope.competitions = response.data.data.upcoming;
+        }, function(error) {
+          console.error(error);
+        }
+    );
+
     $scope.save = function() {
         // Send the form data to the api
         var fd = new FormData();
@@ -65,6 +75,8 @@ app.controller('EditProblemController', ['$scope', '$route', '$http',
             fd.append('sol_file', $scope.solFile);
         if (typeof prob.appeared !== 'undefined')
             fd.append('appeared_in', prob.appeared);
+        if (typeof prob.comp_release !== 'undefined');
+            fd.append('comp_release', parseInt(prob.comp_release));
 
         $http({
             method: ($scope.isCreate ? 'POST' : 'PUT'),

--- a/auacm/app/static/js/controllers/ViewProblemController.js
+++ b/auacm/app/static/js/controllers/ViewProblemController.js
@@ -1,5 +1,5 @@
-app.controller('ViewProblemController', ['$scope', '$route', '$routeParams', '$http',
-        function($scope, $route, $routeParams, $http) {
+app.controller('ViewProblemController', ['$scope', '$route', '$routeParams', '$http', '$window',
+        function($scope, $route, $routeParams, $http, $window) {
     $scope.pid = $routeParams.pid;
 
     $http.get('/api/problems/' + $scope.pid)
@@ -7,6 +7,10 @@ app.controller('ViewProblemController', ['$scope', '$route', '$routeParams', '$h
             $scope.current_prob = response.data.data;
         }, function(error) {
             console.log(error.data.status + ': ' + error.data.error);
+            if (error.status == 404) {
+                $window.location.href = 'http://' + $window.location.host +
+                        '/#/404';
+            }
         }
     );
 }]);


### PR DESCRIPTION
Problems can now be associated with a competition and hidden from users until that competition begins.

**Changes**
- Getting one problem will check if that problem's `comp_release` has started. This adds an extra database query.
- Getting _all_ problems adds a database query to the competitions table, but only one. Start times are stored and checked in memory to minimize performance hit.
- On the front-end, creating/editing a problem has a new competition release field with a dropdown of all upcoming competitions. If selected and saved, the problem is inaccessible to _all_ users (admins can still view by going to the edit route)
  - **Note:** that this means that previously unhidden problems can be made hidden by associating them with a new competition
  - **Note:** adding a problem to a competition does _not_ automatically hide it

This feature also includes unit tests. Because that should be a thing.
